### PR TITLE
Return ERROR_DEVICE if device is not responding

### DIFF
--- a/ds18b20.c
+++ b/ds18b20.c
@@ -282,6 +282,10 @@ static DS18B20_ERROR _read_scratchpad(const DS18B20_Info * ds18b20_info, Scratch
             err = DS18B20_ERROR_OWB;
         }
     }
+    else
+    {
+        err = DS18B20_ERROR_DEVICE;
+    }
     return err;
 }
 


### PR DESCRIPTION
In a previous version of this library, attempting to read from a device that has been disconnected would result in `DS18B20_ERROR_DEVICE`. This behaviour changed in 97fa5ee and now it just returns `DS18B20_ERROR_UNKNOWN`. Nothing in the entire codebase seems to emit `DS18B20_ERROR_DEVICE` anymore, in fact.

This PR returns to the previous behaviour.
