### PR TITLE
Detect power on value and report as error

### DIFF
--- a/ds18b20.c
+++ b/ds18b20.c
@@ -282,6 +282,10 @@ static DS18B20_ERROR _read_scratchpad(const DS18B20_Info * ds18b20_info, Scratch
             err = DS18B20_ERROR_OWB;
         }
     }
+    else
+    {
+        err = DS18B20_ERROR_DEVICE;
+    }
     return err;
 }
 

--- a/ds18b20.c
+++ b/ds18b20.c
@@ -534,6 +534,13 @@ DS18B20_ERROR ds18b20_read_temp(const DS18B20_Info * ds18b20_info, float * value
             temp_MSB = scratchpad.temperature[1];
         }
 
+        // https://github.com/cpetrich/counterfeit_DS18B20#solution-to-the-85-c-problem
+        if (scratchpad.reserved[1] == 0x0c && temp_MSB == 0x05 && temp_LSB == 0x50)
+        {
+            ESP_LOGE(TAG, "Read power-on value (85.0)");
+            err = DS18B20_ERROR_DEVICE;
+        }
+
         float temp = _decode_temp(temp_LSB, temp_MSB, ds18b20_info->resolution);
         ESP_LOGD(TAG, "temp_LSB 0x%02x, temp_MSB 0x%02x, temp %f", temp_LSB, temp_MSB, temp);
 


### PR DESCRIPTION
When attempting to read the temperature from a DS18B20 without first requesting a conversion, it reports 85°C (the power-on value).

This technique inspects one of the other scratchpad bytes, and is able to detect when this value is 85°C due to power-on situation, or whether it has actually measured a temperature of 85°C for real.

Reference: https://github.com/cpetrich/counterfeit_DS18B20#solution-to-the-85-c-problem