### PR TITLE
Fix build with idf v5.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(COMPONENT_ADD_INCLUDEDIRS include)
 set(COMPONENT_SRCS "ds18b20.c")
+set(COMPONENT_REQUIRES "driver" "esp_timer")
 set(COMPONENT_PRIV_REQUIRES "esp32-owb")
 register_component()
-
-

--- a/ds18b20.c
+++ b/ds18b20.c
@@ -41,6 +41,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/gpio.h"
+#include "esp_timer.h"      // for esp_timer_get_time()
 #include "esp_system.h"
 #include "esp_log.h"
 


### PR DESCRIPTION
Minor changes to enable the component to build against `esp-idf` v5.x.
Tested against `esp32-ds18b20-example` and `esp-idf` v5.0.1.
I think this should be OK with the v3.3 - 4.4 builds but I have not been able to test that.